### PR TITLE
Fix typo in Stresses.md

### DIFF
--- a/modules/solid_mechanics/doc/content/modules/solid_mechanics/Stresses.md
+++ b/modules/solid_mechanics/doc/content/modules/solid_mechanics/Stresses.md
@@ -157,7 +157,7 @@ strain required to return the stress state to the yield surface.
 \end{equation}
 where the change in the iterative effective inelastic strain is defined as the yield surface over the
 derivative of the yield surface with respect to the inelastic strain increment. In the case of
-isotropic linear hardening plasticity, with the hardening function $ r = hp$, the effective plastic
+isotropic linear hardening plasticity, with the hardening function $r = hp$, the effective plastic
 strain increment has the form:
 \begin{equation}
  d \Delta p = \frac{\sigma^{trial}_{effective} - 3 G \Delta p - r - \sigma_{yield}}{3G + h}


### PR DESCRIPTION
## Reason
There appears to be a LaTeX rendering issue [in the documentation here](https://mooseframework.inl.gov/modules/solid_mechanics/Stresses.html):

<img width="1299" height="448" alt="image" src="https://github.com/user-attachments/assets/99381448-e081-4a49-b592-673e5ed25c69" />

Which I believe is caused by the extra leading space in `$ r = hp$` as making this one change and then locally building the docs results in:

<img width="1656" height="462" alt="image" src="https://github.com/user-attachments/assets/33463405-f9b6-48f2-8731-6c9cf6b6b91b" />

## Design
Remove an errant white space.

## Impact
Fixes rendering of documentation.


This PR fixes https://github.com/idaholab/moose/issues/31639
